### PR TITLE
Fix download apple app

### DIFF
--- a/option/hostsVN.conf
+++ b/option/hostsVN.conf
@@ -105,7 +105,6 @@ FINAL,DIRECT
 
 [Host]
 ocsp.apple.com = 0.0.0.0
-appldnld.apple.com = 0.0.0.0
 mesu.apple.com = 0.0.0.0
 doubleclick.net = 0.0.0.0
 g.doubleclick.net = 0.0.0.0

--- a/option/hostsVN4iOS
+++ b/option/hostsVN4iOS
@@ -1,5 +1,5 @@
 # Title: hostsVN
-# Updated: Aug 14 2018
+# Updated: Aug 18 2018
 # Minimal version for iOS
 # Please report any unblocked ads or problems by github
 # Github: https://github.com/bigdargon/hostsVN/

--- a/option/hostsVN4iOS
+++ b/option/hostsVN4iOS
@@ -8,7 +8,6 @@
 #
 # =====================================================
 0 ocsp.apple.com
-0 appldnld.apple.com
 0 mesu.apple.com
 # BEGIN hostsVN ---
 # --- Group block ---


### PR DESCRIPTION
Bỏ chặn tên miền `appldnld.apple.com` do không tải được một số ứng dụng mặc định của Apple từ Appstore