### PR TITLE
Whitelist Apple OCSP domains

### DIFF
--- a/hosts
+++ b/hosts
@@ -12,8 +12,6 @@
 
 # --- Group block ---
 #[apple]
-0.0.0.0 ocsp.apple.com
-0.0.0.0 www.ocsp.apple.com
 0.0.0.0 advertising.apple.com
 0.0.0.0 banners.itunes.apple.com
 #[iadsdk.apple.com]


### PR DESCRIPTION
Hello! Quick PR for you today.

Blocking OCSP has adverse side effects to Apple applications, such as Find my Phone.

Thanks!