### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+hosts linguist-detectable linguist-language=hosts
+hosts-* linguist-detectable linguist-language=hosts
+gambling0* linguist-detectable linguist-language=hosts
+
+/filters/* linguist-detectable linguist-language=AdBlock
+filter.txt linguist-detectable linguist-language=AdBlock
+filter-VN.txt linguist-detectable linguist-language=AdBlock
+wildcard.txt linguist-detectable linguist-language=AdBlock
+wildcard-VN.txt linguist-detectable linguist-language=AdBlock


### PR DESCRIPTION
.gitattributes is a file that can to varying extents add colours to text files, depending on GitHub Linguist. This means that adblock lists' special characters can be shown in red, hosts entries in blue, and comments in grey.

For the occasion of a Linguist update earlier today (Wednesday) that added Hosts support, I decided to write such a file for this repo.

![image](https://github.com/bigdargon/hostsVN/assets/22780683/259a3318-5eac-4441-8b78-4fc20c316c21)