### PR TITLE
Add fraud chamsocthekhachhang-thang4.com.vn

### DIFF
--- a/source/hosts-VN.txt
+++ b/source/hosts-VN.txt
@@ -294,6 +294,7 @@
 0.0.0.0 bubblyzucchini.com
 0.0.0.0 campaign.gitiho.com
 0.0.0.0 cdn.api-connect.io
+0.0.0.0 chamsocthekhachhang-thang4.com.vn
 0.0.0.0 clicker.chiaki.vn
 0.0.0.0 clientinfo.phimmoizz.net
 0.0.0.0 collect.ovp.vn
@@ -457,6 +458,7 @@
 0.0.0.0 thongke.thethaovanhoa.vn
 0.0.0.0 thongke.vui.vn
 0.0.0.0 thongke99.baogiaothong.vn
+0.0.0.0 tpbank.chamsocthekhachhang-thang4.com.vn
 0.0.0.0 tr.topdevvn.com
 0.0.0.0 tracer.concung.com
 0.0.0.0 track-srv.vietnamnet.vn


### PR DESCRIPTION
- Navigate to https://tpbank.chamsocthekhachhang-thang4.com.vn/
- Click "Huy the khach hang"
- It tricks you into giving the CC details

Should block both the domain and subdomain. Not sure if there are other scam subdomains reported elsewhere.

Thinking about adding wildcard host to this PR but I couldn't find a contribution guide, and `hosts` does not support wildcard (but maybe some app-specific formats support it.)