### PR TITLE
Could you please remove cdn.pubnub.com from the black list

### DIFF
--- a/hosts
+++ b/hosts
@@ -20123,7 +20123,6 @@
 0.0.0.0 cdn.lr-ingest.io
 0.0.0.0 cdn.onesignal.com
 0.0.0.0 cdn.promotionengine.com
-0.0.0.0 cdn.pubnub.com
 0.0.0.0 cdn.retailads.net
 0.0.0.0 cdn.shoplytics.com
 0.0.0.0 cdn.traffic60s.xyz


### PR DESCRIPTION
Could you please remove cdn.pubnub.com from the black list ? We(PubNub) are providing platform for real-time interactive application. You can find more info about us here: https://www.pubnub.com/